### PR TITLE
DB Params Option 

### DIFF
--- a/options.go
+++ b/options.go
@@ -42,9 +42,9 @@ func WithTrimSQLInSpanName() Option {
 	})
 }
 
-// WithDisableSQLStatementInBaggage will disable logging the SQL statement in
-// the span's baggage.
-func WithDisableSQLStatementInBaggage() Option {
+// WithDisableSQLStatementInAttributes will disable logging the SQL statement in the span's
+// attributes.
+func WithDisableSQLStatementInAttributes() Option {
 	return optionFunc(func(cfg *tracerConfig) {
 		cfg.logSQLStatement = false
 	})

--- a/options.go
+++ b/options.go
@@ -49,3 +49,11 @@ func WithDisableSQLStatementInAttributes() Option {
 		cfg.logSQLStatement = false
 	})
 }
+
+// WithIncludeParams makes the query's parameters included as a span attribute pgx.db.params.
+// This is implicitly disabled if WithDisableSQLStatementInAttributes is used.
+func WithIncludeParams() Option {
+	return optionFunc(func(cfg *tracerConfig) {
+		cfg.includeParams = true
+	})
+}

--- a/options.go
+++ b/options.go
@@ -50,9 +50,9 @@ func WithDisableSQLStatementInAttributes() Option {
 	})
 }
 
-// WithIncludeParams makes the query's parameters included as a span attribute pgx.db.params.
+// WithIncludeQueryParameters includes the SQL query parameters in the span attribute with key pgx.query.parameters.
 // This is implicitly disabled if WithDisableSQLStatementInAttributes is used.
-func WithIncludeParams() Option {
+func WithIncludeQueryParameters() Option {
 	return optionFunc(func(cfg *tracerConfig) {
 		cfg.includeParams = true
 	})

--- a/tracer.go
+++ b/tracer.go
@@ -303,5 +303,5 @@ func makeParamsAttribute(args []any) attribute.KeyValue {
 	}
 	// Since there doesn't appear to be a standard key for this in semconv, prefix it to avoid
 	// clashing with future standard attributes.
-	return attribute.Key("pgx.db.params").StringSlice(ss)
+	return attribute.Key("pgx.query.parameters").StringSlice(ss)
 }


### PR DESCRIPTION
This also fixes the naming of the `WithDisableSQLStatementInBaggage`.  Since this is pre-1.0 and given that it was incorrect anyway I broke backwards compatibility.

Closes #13.