### PR TITLE
Handle sql.ErrNoRows properly

### DIFF
--- a/internal/constants.go
+++ b/internal/constants.go
@@ -7,5 +7,5 @@ const (
 
 	// InstrumentationVersion is the version of the otelpgx library. This will
 	// be used as an attribute on each span.
-	InstrumentationVersion = "v0.5.1"
+	InstrumentationVersion = "v0.5.2"
 )

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -34,13 +34,13 @@ func TestTracer_sqlOperationName(t *testing.T) {
 			name:    "Whitespace-only query",
 			query:   " \n\t",
 			tracer:  NewTracer(),
-			expName: sqlOperationUnknkown,
+			expName: sqlOperationUnknown,
 		},
 		{
 			name:    "Empty query",
 			query:   "",
 			tracer:  NewTracer(),
-			expName: sqlOperationUnknkown,
+			expName: sqlOperationUnknown,
 		},
 		{
 			name:    "Functional span name (-- comment style)",
@@ -64,19 +64,19 @@ func TestTracer_sqlOperationName(t *testing.T) {
 			name:    "Functional span name (no annotation)",
 			query:   "--\nSELECT * FROM user",
 			tracer:  NewTracer(WithSpanNameFunc(defaultSpanNameFunc)),
-			expName: sqlOperationUnknkown,
+			expName: sqlOperationUnknown,
 		},
 		{
 			name:    "Custom SQL name query (normal comment)",
 			query:   "-- foo \nSELECT * FROM users",
 			tracer:  NewTracer(WithSpanNameFunc(defaultSpanNameFunc)),
-			expName: sqlOperationUnknkown,
+			expName: sqlOperationUnknown,
 		},
 		{
 			name:    "Custom SQL name query (invalid formatting)",
 			query:   "foo \nSELECT * FROM users",
 			tracer:  NewTracer(WithSpanNameFunc(defaultSpanNameFunc)),
-			expName: sqlOperationUnknkown,
+			expName: sqlOperationUnknown,
 		},
 	}
 	for _, tt := range tests {
@@ -115,7 +115,7 @@ var defaultSpanNameFunc SpanNameFunc = func(query string) string {
 			continue
 		}
 		if !strings.HasPrefix(rest, " name: ") {
-			return sqlOperationUnknkown
+			return sqlOperationUnknown
 		}
 
 		part := strings.Split(strings.TrimSpace(line), " ")
@@ -123,7 +123,7 @@ var defaultSpanNameFunc SpanNameFunc = func(query string) string {
 			part = part[:len(part)-1] // removes the trailing "*/" element
 		}
 		if len(part) == 2 {
-			return sqlOperationUnknkown
+			return sqlOperationUnknown
 		}
 
 		queryName := part[2]
@@ -131,5 +131,5 @@ var defaultSpanNameFunc SpanNameFunc = func(query string) string {
 
 		return queryName + " " + queryType
 	}
-	return sqlOperationUnknkown
+	return sqlOperationUnknown
 }


### PR DESCRIPTION
It's quite common to not mark span with error status on `*sql.ErrNoRows` errors. For example:
* https://github.com/uptrace/opentelemetry-go-extra/blob/main/otelsql/otel.go#L118
* https://github.com/go-gorm/opentelemetry/blob/master/tracing/tracing.go#L144