### PR TITLE
feat: add an option to remove the query span name prefix

### DIFF
--- a/options.go
+++ b/options.go
@@ -57,6 +57,14 @@ func WithSpanNameFunc(fn SpanNameFunc) Option {
 	})
 }
 
+// WithDisableQuerySpanNamePrefix will disable the default prefix for the span
+// name. By default, the span name is prefixed with "batch query" or "query".
+func WithDisableQuerySpanNamePrefix() Option {
+	return optionFunc(func(cfg *tracerConfig) {
+		cfg.prefixQuerySpanName = false
+	})
+}
+
 // WithDisableSQLStatementInAttributes will disable logging the SQL statement in the span's
 // attributes.
 func WithDisableSQLStatementInAttributes() Option {


### PR DESCRIPTION
Hello !
I don't want the prefix in my spans so here's a way to remove without breaking changes.