### PR TITLE
feat: add ability to disable logging connection details in query spans

### DIFF
--- a/options.go
+++ b/options.go
@@ -93,6 +93,14 @@ func WithDisableQuerySpanNamePrefix() Option {
 	})
 }
 
+// WithDisableConnectionDetailsInAttributes will disable logging the connection details.
+// in the span's attributes.
+func WithDisableConnectionDetailsInAttributes() Option {
+	return optionFunc(func(cfg *tracerConfig) {
+		cfg.logConnectionDetails = false
+	})
+}
+
 // WithDisableSQLStatementInAttributes will disable logging the SQL statement in the span's
 // attributes.
 func WithDisableSQLStatementInAttributes() Option {


### PR DESCRIPTION
This adds the ability to disable logging connection details in query spans to avoid clutter.
It still logs in the connect span since that happens less frequently and is relevant.

I've also changed the function that created the connection details attributes to no longer create a slice since it only had one element that was immediately extracted anyways.