### PR TITLE
fix: handle single word statements in operation name

### DIFF
--- a/tracer.go
+++ b/tracer.go
@@ -198,14 +198,17 @@ func (t *Tracer) sqlOperationName(stmt string) string {
 
 	// NOTE: Can convert to FieldsSeq in go 1.24+ which avoids allocations.
 	stmt = strings.TrimSpace(stmt)
-	spaceIdx := strings.IndexFunc(stmt, unicode.IsSpace)
-	if spaceIdx <= 0 {
+	end := strings.IndexFunc(stmt, unicode.IsSpace)
+	if end < 0 && len(stmt) > 0 {
+		// No space found, use the whole statement.
+		end = len(stmt)
+	} else if end < 0 {
 		// Fall back to a fixed value to prevent creating lots of tracing operations
 		// differing only by the amount of whitespace in them (in case we'd fall back
 		// to the full query or a cut-off version).
 		return sqlOperationUnknown
 	}
-	return strings.ToUpper(stmt[:spaceIdx])
+	return strings.ToUpper(stmt[:end])
 }
 
 // connectionAttributesFromConfig returns a SpanStartOption that contains

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -31,6 +31,12 @@ func TestTracer_sqlOperationName(t *testing.T) {
 			expName: "SELECT",
 		},
 		{
+			name:    "Single word statement",
+			query:   "BEGIN",
+			tracer:  NewTracer(),
+			expName: "BEGIN",
+		},
+		{
 			name:    "Whitespace-only query",
 			query:   " \n\t",
 			tracer:  NewTracer(),


### PR DESCRIPTION
Otherwise statements like `BEGIN` and `COMMIT` end up with a `query UNKNOWN` operation name.