### PR TITLE
chore: use custom context key type

### DIFF
--- a/tracer.go
+++ b/tracer.go
@@ -21,10 +21,12 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+type contextKey int8
+
 const (
 	tracerName          = "github.com/exaring/otelpgx"
 	meterName           = "github.com/exaring/otelpgx"
-	startTimeCtxKey     = "otelpgxStartTime"
+	startTimeCtxKey     = contextKey(0)
 	sqlOperationUnknown = "UNKNOWN"
 )
 


### PR DESCRIPTION
Use a custom context key type to prevent key collisions.

See [go blog](https://go.dev/blog/context#package-userip) for details