### PR TITLE
change meter names type - var to const

### DIFF
--- a/meter.go
+++ b/meter.go
@@ -18,7 +18,7 @@ const (
 	defaultMinimumReadDBStatsInterval = time.Second
 )
 
-var (
+const (
 	pgxPoolAcquireCount            = "pgxpool.acquires"
 	pgxPoolAcquireDuration         = "pgxpool.acquire_duration"
 	pgxPoolAcquiredConnections     = "pgxpool.acquired_connections"


### PR DESCRIPTION
Using const instead of global var for metric names is preferred