### PR TITLE
feat: add option to disable tracing

### DIFF
--- a/options.go
+++ b/options.go
@@ -117,6 +117,14 @@ func WithIncludeQueryParameters() Option {
 	})
 }
 
+// WithDisableTracing will disable tracing operations minimizing performance overhead it brings.
+// Metrics operations are not affected by this option and will still be performed.
+func WithDisableTracing() Option {
+	return optionFunc(func(cfg *tracerConfig) {
+		cfg.disableTracing = true
+	})
+}
+
 // StatsOption allows for managing RecordStats configuration using functional options.
 type StatsOption interface {
 	applyStatsOptions(o *statsOptions)

--- a/tracer.go
+++ b/tracer.go
@@ -70,6 +70,7 @@ type Tracer struct {
 	logSQLStatement      bool
 	logConnectionDetails bool
 	includeParams        bool
+	disableTracing       bool
 }
 
 type tracerConfig struct {
@@ -85,6 +86,7 @@ type tracerConfig struct {
 	logSQLStatement      bool
 	logConnectionDetails bool
 	includeParams        bool
+	disableTracing       bool
 }
 
 // NewTracer returns a new Tracer.
@@ -120,6 +122,7 @@ func NewTracer(opts ...Option) *Tracer {
 		prefixQuerySpanName: cfg.prefixQuerySpanName,
 		logSQLStatement:     cfg.logSQLStatement,
 		includeParams:       cfg.includeParams,
+		disableTracing:      cfg.disableTracing,
 	}
 
 	tracer.createMetrics()
@@ -199,12 +202,18 @@ func connectionAttributesFromConfig(config *pgx.ConnConfig) trace.SpanStartOptio
 	return nil
 }
 
+// skipTracing determines whether tracing operations are undesirable or worthless
+// and, therefore, should not be performed.
+func (t *Tracer) skipTracing(span trace.Span) bool {
+	return t.disableTracing || !span.IsRecording()
+}
+
 // TraceQueryStart is called at the beginning of Query, QueryRow, and Exec calls.
 // The returned context is used for the rest of the call and will be passed to TraceQueryEnd.
 func (t *Tracer) TraceQueryStart(ctx context.Context, conn *pgx.Conn, data pgx.TraceQueryStartData) context.Context {
 	ctx = context.WithValue(ctx, startTimeCtxKey, time.Now())
 
-	if !trace.SpanFromContext(ctx).IsRecording() {
+	if t.skipTracing(trace.SpanFromContext(ctx)) {
 		return ctx
 	}
 
@@ -246,16 +255,20 @@ func (t *Tracer) TraceQueryStart(ctx context.Context, conn *pgx.Conn, data pgx.T
 // TraceQueryEnd is called at the end of Query, QueryRow, and Exec calls.
 func (t *Tracer) TraceQueryEnd(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryEndData) {
 	span := trace.SpanFromContext(ctx)
-	recordSpanError(span, data.Err)
 	t.incrementOperationErrorCount(ctx, data.Err, pgxOperationQuery)
+	t.recordOperationDuration(ctx, pgxOperationQuery)
+
+	if t.skipTracing(span) {
+		return
+	}
+
+	recordSpanError(span, data.Err)
 
 	if data.Err == nil {
 		span.SetAttributes(RowsAffectedKey.Int64(data.CommandTag.RowsAffected()))
 	}
 
 	span.End()
-
-	t.recordOperationDuration(ctx, pgxOperationQuery)
 }
 
 // TraceCopyFromStart is called at the beginning of CopyFrom calls. The
@@ -264,7 +277,7 @@ func (t *Tracer) TraceQueryEnd(ctx context.Context, _ *pgx.Conn, data pgx.TraceQ
 func (t *Tracer) TraceCopyFromStart(ctx context.Context, conn *pgx.Conn, data pgx.TraceCopyFromStartData) context.Context {
 	ctx = context.WithValue(ctx, startTimeCtxKey, time.Now())
 
-	if !trace.SpanFromContext(ctx).IsRecording() {
+	if t.skipTracing(trace.SpanFromContext(ctx)) {
 		return ctx
 	}
 
@@ -287,16 +300,19 @@ func (t *Tracer) TraceCopyFromStart(ctx context.Context, conn *pgx.Conn, data pg
 // TraceCopyFromEnd is called at the end of CopyFrom calls.
 func (t *Tracer) TraceCopyFromEnd(ctx context.Context, _ *pgx.Conn, data pgx.TraceCopyFromEndData) {
 	span := trace.SpanFromContext(ctx)
-	recordSpanError(span, data.Err)
 	t.incrementOperationErrorCount(ctx, data.Err, pgxOperationCopy)
+	t.recordOperationDuration(ctx, pgxOperationCopy)
+
+	if t.skipTracing(span) {
+		return
+	}
 
 	if data.Err == nil {
 		span.SetAttributes(RowsAffectedKey.Int64(data.CommandTag.RowsAffected()))
 	}
 
+	recordSpanError(span, data.Err)
 	span.End()
-
-	t.recordOperationDuration(ctx, pgxOperationCopy)
 }
 
 // TraceBatchStart is called at the beginning of SendBatch calls. The returned
@@ -305,7 +321,7 @@ func (t *Tracer) TraceCopyFromEnd(ctx context.Context, _ *pgx.Conn, data pgx.Tra
 func (t *Tracer) TraceBatchStart(ctx context.Context, conn *pgx.Conn, data pgx.TraceBatchStartData) context.Context {
 	ctx = context.WithValue(ctx, startTimeCtxKey, time.Now())
 
-	if !trace.SpanFromContext(ctx).IsRecording() {
+	if t.skipTracing(trace.SpanFromContext(ctx)) {
 		return ctx
 	}
 
@@ -334,7 +350,7 @@ func (t *Tracer) TraceBatchStart(ctx context.Context, conn *pgx.Conn, data pgx.T
 func (t *Tracer) TraceBatchQuery(ctx context.Context, conn *pgx.Conn, data pgx.TraceBatchQueryData) {
 	t.incrementOperationErrorCount(ctx, data.Err, pgxOperationBatch)
 
-	if !trace.SpanFromContext(ctx).IsRecording() {
+	if t.skipTracing(trace.SpanFromContext(ctx)) {
 		return
 	}
 
@@ -381,12 +397,15 @@ func (t *Tracer) TraceBatchQuery(ctx context.Context, conn *pgx.Conn, data pgx.T
 // TraceBatchEnd is called at the end of SendBatch calls.
 func (t *Tracer) TraceBatchEnd(ctx context.Context, _ *pgx.Conn, data pgx.TraceBatchEndData) {
 	span := trace.SpanFromContext(ctx)
-	recordSpanError(span, data.Err)
 	t.incrementOperationErrorCount(ctx, data.Err, pgxOperationBatch)
-
-	span.End()
-
 	t.recordOperationDuration(ctx, pgxOperationBatch)
+
+	if t.skipTracing(span) {
+		return
+	}
+
+	recordSpanError(span, data.Err)
+	span.End()
 }
 
 // TraceConnectStart is called at the beginning of Connect and ConnectConfig
@@ -395,7 +414,7 @@ func (t *Tracer) TraceBatchEnd(ctx context.Context, _ *pgx.Conn, data pgx.TraceB
 func (t *Tracer) TraceConnectStart(ctx context.Context, data pgx.TraceConnectStartData) context.Context {
 	ctx = context.WithValue(ctx, startTimeCtxKey, time.Now())
 
-	if !trace.SpanFromContext(ctx).IsRecording() {
+	if t.skipTracing(trace.SpanFromContext(ctx)) {
 		return ctx
 	}
 
@@ -417,12 +436,15 @@ func (t *Tracer) TraceConnectStart(ctx context.Context, data pgx.TraceConnectSta
 // TraceConnectEnd is called at the end of Connect and ConnectConfig calls.
 func (t *Tracer) TraceConnectEnd(ctx context.Context, data pgx.TraceConnectEndData) {
 	span := trace.SpanFromContext(ctx)
-	recordSpanError(span, data.Err)
 	t.incrementOperationErrorCount(ctx, data.Err, pgxOperationConnect)
-
-	span.End()
-
 	t.recordOperationDuration(ctx, pgxOperationConnect)
+
+	if t.skipTracing(span) {
+		return
+	}
+
+	recordSpanError(span, data.Err)
+	span.End()
 }
 
 // TracePrepareStart is called at the beginning of Prepare calls. The returned
@@ -431,7 +453,7 @@ func (t *Tracer) TraceConnectEnd(ctx context.Context, data pgx.TraceConnectEndDa
 func (t *Tracer) TracePrepareStart(ctx context.Context, conn *pgx.Conn, data pgx.TracePrepareStartData) context.Context {
 	ctx = context.WithValue(ctx, startTimeCtxKey, time.Now())
 
-	if !trace.SpanFromContext(ctx).IsRecording() {
+	if t.skipTracing(trace.SpanFromContext(ctx)) {
 		return ctx
 	}
 
@@ -471,12 +493,15 @@ func (t *Tracer) TracePrepareStart(ctx context.Context, conn *pgx.Conn, data pgx
 // TracePrepareEnd is called at the end of Prepare calls.
 func (t *Tracer) TracePrepareEnd(ctx context.Context, _ *pgx.Conn, data pgx.TracePrepareEndData) {
 	span := trace.SpanFromContext(ctx)
-	recordSpanError(span, data.Err)
 	t.incrementOperationErrorCount(ctx, data.Err, pgxOperationPrepare)
-
-	span.End()
-
 	t.recordOperationDuration(ctx, pgxOperationPrepare)
+
+	if t.skipTracing(span) {
+		return
+	}
+
+	recordSpanError(span, data.Err)
+	span.End()
 }
 
 // TraceAcquireStart is called at the beginning of Acquire.
@@ -484,7 +509,7 @@ func (t *Tracer) TracePrepareEnd(ctx context.Context, _ *pgx.Conn, data pgx.Trac
 func (t *Tracer) TraceAcquireStart(ctx context.Context, pool *pgxpool.Pool, data pgxpool.TraceAcquireStartData) context.Context {
 	ctx = context.WithValue(ctx, startTimeCtxKey, time.Now())
 
-	if !trace.SpanFromContext(ctx).IsRecording() {
+	if t.skipTracing(trace.SpanFromContext(ctx)) {
 		return ctx
 	}
 
@@ -506,12 +531,15 @@ func (t *Tracer) TraceAcquireStart(ctx context.Context, pool *pgxpool.Pool, data
 // TraceAcquireEnd is called when a connection has been acquired.
 func (t *Tracer) TraceAcquireEnd(ctx context.Context, _ *pgxpool.Pool, data pgxpool.TraceAcquireEndData) {
 	span := trace.SpanFromContext(ctx)
-	recordSpanError(span, data.Err)
 	t.incrementOperationErrorCount(ctx, data.Err, pgxOperationAcquire)
-
-	span.End()
-
 	t.recordOperationDuration(ctx, pgxOperationAcquire)
+
+	if t.skipTracing(span) {
+		return
+	}
+
+	recordSpanError(span, data.Err)
+	span.End()
 }
 
 func makeParamsAttribute(args []any) attribute.KeyValue {


### PR DESCRIPTION
This pull request introduces an option to significantly reduce the overhead caused by tracing instrumentation inside `Tracer` implementation in scenarios where it is not used. Metrics operations will still be performed, and their logic remains unaffected by this change. 

While otepgx already offers a method to disable tracing by providing a noop traceprovider via option, the operations that prepare trace attributes still remain. Their results will not be used, so these operations are not needed, but they still consume resources.

Here is the benchmark result demonstrating improvements:
```
goos: linux
goarch: amd64
pkg: github.com/exaring/otelpgx
cpu: Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz
          │ NoopTraceProvider │      WithDisableTracing       │
          │      sec/op       │   sec/op     vs base          │
Tracer-16         740.0µ ± 2%   738.2µ ± 1%  ~ (p=0.853 n=10)

          │ NoopTraceProvider │          WithDisableTracing          │
          │       B/op        │     B/op      vs base                │
Tracer-16        3.438Ki ± 0%   1.884Ki ± 0%  -45.20% (p=0.000 n=10)

          │ NoopTraceProvider │         WithDisableTracing         │
          │     allocs/op     │ allocs/op   vs base                │
Tracer-16          65.00 ± 0%   34.00 ± 0%  -47.69% (p=0.000 n=10)
```