### PR TITLE
feat: use pools for attributes and options

### DIFF
--- a/operation_name_go124.go
+++ b/operation_name_go124.go
@@ -7,13 +7,9 @@ import (
 	"strings"
 )
 
-// sqlOperationName attempts to get the first 'word' from a given SQL query, which usually
+// defaultSpanNameFunc attempts to get the first 'word' from a given SQL query, which usually
 // is the operation name (e.g. 'SELECT').
-func (t *Tracer) sqlOperationName(stmt string) string {
-	if t.spanNameFunc != nil {
-		return t.spanNameFunc(stmt)
-	}
-
+func defaultSpanNameFunc(stmt string) string {
 	for word := range strings.FieldsSeq(stmt) {
 		return strings.ToUpper(word)
 	}

--- a/operation_name_legacy.go
+++ b/operation_name_legacy.go
@@ -8,16 +8,9 @@ import (
 	"unicode"
 )
 
-// sqlOperationName attempts to get the first 'word' from a given SQL query, which usually
+// defaultSpanNameFunc attempts to get the first 'word' from a given SQL query, which usually
 // is the operation name (e.g. 'SELECT').
-func (t *Tracer) sqlOperationName(stmt string) string {
-	// If a custom function is provided, use that. Otherwise, fall back to the
-	// default implementation. This allows users to override the default
-	// behavior without having to reimplement it.
-	if t.spanNameFunc != nil {
-		return t.spanNameFunc(stmt)
-	}
-
+func defaultSpanNameFunc(stmt string) string {
 	stmt = strings.TrimSpace(stmt)
 	end := strings.IndexFunc(stmt, unicode.IsSpace)
 	if end < 0 && len(stmt) > 0 {

--- a/tracer.go
+++ b/tracer.go
@@ -20,9 +20,11 @@ import (
 )
 
 const (
-	tracerName          = "github.com/exaring/otelpgx"
-	meterName           = "github.com/exaring/otelpgx"
-	startTimeCtxKey     = "otelpgxStartTime"
+	tracerName = "github.com/exaring/otelpgx"
+	meterName  = "github.com/exaring/otelpgx"
+)
+
+const (
 	sqlOperationUnknown = "UNKNOWN"
 )
 
@@ -50,6 +52,8 @@ const (
 	// DBClientOperationErrorsKey represents the count of operation errors
 	DBClientOperationErrorsKey = attribute.Key("db.client.operation.errors")
 )
+
+type startTimeCtxKey struct{}
 
 var _ pgxpool.AcquireTracer = (*Tracer)(nil)
 
@@ -177,7 +181,7 @@ func (t *Tracer) incrementOperationErrorCount(ctx context.Context, err error, pg
 
 // recordOperationDuration will compute and record the time since the start of an operation.
 func (t *Tracer) recordOperationDuration(ctx context.Context, pgxOperation string) {
-	if startTime, ok := ctx.Value(startTimeCtxKey).(time.Time); ok {
+	if startTime, ok := ctx.Value(startTimeCtxKey{}).(time.Time); ok {
 		t.operationDuration.Record(ctx, time.Since(startTime).Milliseconds(), metric.WithAttributeSet(
 			attribute.NewSet(append(t.meterAttrs, PGXOperationTypeKey.String(pgxOperation))...),
 		))
@@ -202,7 +206,7 @@ func connectionAttributesFromConfig(config *pgx.ConnConfig) trace.SpanStartOptio
 // TraceQueryStart is called at the beginning of Query, QueryRow, and Exec calls.
 // The returned context is used for the rest of the call and will be passed to TraceQueryEnd.
 func (t *Tracer) TraceQueryStart(ctx context.Context, conn *pgx.Conn, data pgx.TraceQueryStartData) context.Context {
-	ctx = context.WithValue(ctx, startTimeCtxKey, time.Now())
+	ctx = context.WithValue(ctx, startTimeCtxKey{}, time.Now())
 
 	if !trace.SpanFromContext(ctx).IsRecording() {
 		return ctx
@@ -262,7 +266,7 @@ func (t *Tracer) TraceQueryEnd(ctx context.Context, _ *pgx.Conn, data pgx.TraceQ
 // returned context is used for the rest of the call and will be passed to
 // TraceCopyFromEnd.
 func (t *Tracer) TraceCopyFromStart(ctx context.Context, conn *pgx.Conn, data pgx.TraceCopyFromStartData) context.Context {
-	ctx = context.WithValue(ctx, startTimeCtxKey, time.Now())
+	ctx = context.WithValue(ctx, startTimeCtxKey{}, time.Now())
 
 	if !trace.SpanFromContext(ctx).IsRecording() {
 		return ctx
@@ -303,7 +307,7 @@ func (t *Tracer) TraceCopyFromEnd(ctx context.Context, _ *pgx.Conn, data pgx.Tra
 // context is used for the rest of the call and will be passed to
 // TraceBatchQuery and TraceBatchEnd.
 func (t *Tracer) TraceBatchStart(ctx context.Context, conn *pgx.Conn, data pgx.TraceBatchStartData) context.Context {
-	ctx = context.WithValue(ctx, startTimeCtxKey, time.Now())
+	ctx = context.WithValue(ctx, startTimeCtxKey{}, time.Now())
 
 	if !trace.SpanFromContext(ctx).IsRecording() {
 		return ctx
@@ -393,7 +397,7 @@ func (t *Tracer) TraceBatchEnd(ctx context.Context, _ *pgx.Conn, data pgx.TraceB
 // calls. The returned context is used for the rest of the call and will be
 // passed to TraceConnectEnd.
 func (t *Tracer) TraceConnectStart(ctx context.Context, data pgx.TraceConnectStartData) context.Context {
-	ctx = context.WithValue(ctx, startTimeCtxKey, time.Now())
+	ctx = context.WithValue(ctx, startTimeCtxKey{}, time.Now())
 
 	if !trace.SpanFromContext(ctx).IsRecording() {
 		return ctx
@@ -429,7 +433,7 @@ func (t *Tracer) TraceConnectEnd(ctx context.Context, data pgx.TraceConnectEndDa
 // context is used for the rest of the call and will be passed to
 // TracePrepareEnd.
 func (t *Tracer) TracePrepareStart(ctx context.Context, conn *pgx.Conn, data pgx.TracePrepareStartData) context.Context {
-	ctx = context.WithValue(ctx, startTimeCtxKey, time.Now())
+	ctx = context.WithValue(ctx, startTimeCtxKey{}, time.Now())
 
 	if !trace.SpanFromContext(ctx).IsRecording() {
 		return ctx
@@ -482,7 +486,7 @@ func (t *Tracer) TracePrepareEnd(ctx context.Context, _ *pgx.Conn, data pgx.Trac
 // TraceAcquireStart is called at the beginning of Acquire.
 // The returned context is used for the rest of the call and will be passed to the TraceAcquireEnd.
 func (t *Tracer) TraceAcquireStart(ctx context.Context, pool *pgxpool.Pool, data pgxpool.TraceAcquireStartData) context.Context {
-	ctx = context.WithValue(ctx, startTimeCtxKey, time.Now())
+	ctx = context.WithValue(ctx, startTimeCtxKey{}, time.Now())
 
 	if !trace.SpanFromContext(ctx).IsRecording() {
 		return ctx

--- a/tracer_benchmark_test.go
+++ b/tracer_benchmark_test.go
@@ -1,3 +1,6 @@
+//go:build go1.24
+// +build go1.24
+
 package otelpgx_test
 
 import (
@@ -41,8 +44,7 @@ func BenchmarkTracer(b *testing.B) {
 	var maxConns int32
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		tx, err := pool.Begin(ctx)
 		if err != nil {
 			b.Fatal(err)

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -51,53 +51,53 @@ func TestTracer_sqlOperationName(t *testing.T) {
 		{
 			name:    "Functional span name (-- comment style)",
 			query:   "-- name: GetUsers :many\nSELECT * FROM users",
-			tracer:  NewTracer(WithSpanNameFunc(defaultSpanNameFunc)),
+			tracer:  NewTracer(WithSpanNameFunc(testSpanNameFunc)),
 			expName: "GetUsers :many",
 		},
 		{
 			name:    "Functional span name (/**/ comment style)",
 			query:   "/* name: GetBooks :many */\nSELECT * FROM books",
-			tracer:  NewTracer(WithSpanNameFunc(defaultSpanNameFunc)),
+			tracer:  NewTracer(WithSpanNameFunc(testSpanNameFunc)),
 			expName: "GetBooks :many",
 		},
 		{
 			name:    "Functional span name (# comment style)",
 			query:   "# name: GetRecords :many\nSELECT * FROM records",
-			tracer:  NewTracer(WithSpanNameFunc(defaultSpanNameFunc)),
+			tracer:  NewTracer(WithSpanNameFunc(testSpanNameFunc)),
 			expName: "GetRecords :many",
 		},
 		{
 			name:    "Functional span name (no annotation)",
 			query:   "--\nSELECT * FROM user",
-			tracer:  NewTracer(WithSpanNameFunc(defaultSpanNameFunc)),
+			tracer:  NewTracer(WithSpanNameFunc(testSpanNameFunc)),
 			expName: sqlOperationUnknown,
 		},
 		{
 			name:    "Custom SQL name query (normal comment)",
 			query:   "-- foo \nSELECT * FROM users",
-			tracer:  NewTracer(WithSpanNameFunc(defaultSpanNameFunc)),
+			tracer:  NewTracer(WithSpanNameFunc(testSpanNameFunc)),
 			expName: sqlOperationUnknown,
 		},
 		{
 			name:    "Custom SQL name query (invalid formatting)",
 			query:   "foo \nSELECT * FROM users",
-			tracer:  NewTracer(WithSpanNameFunc(defaultSpanNameFunc)),
+			tracer:  NewTracer(WithSpanNameFunc(testSpanNameFunc)),
 			expName: sqlOperationUnknown,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tr := tt.tracer
-			if got := tr.sqlOperationName(tt.query); got != tt.expName {
+			if got := tr.spanNameFunc(tt.query); got != tt.expName {
 				t.Errorf("Tracer.sqlOperationName() = %v, want %v", got, tt.expName)
 			}
 		})
 	}
 }
 
-// defaultSpanNameFunc is an utility function for testing that attempts to get
+// testSpanNameFunc is an utility function for testing that attempts to get
 // the first name of the query from a given SQL statement.
-var defaultSpanNameFunc SpanNameFunc = func(query string) string {
+var testSpanNameFunc SpanNameFunc = func(query string) string {
 	for _, line := range strings.Split(query, "\n") {
 		var prefix string
 		switch {


### PR DESCRIPTION
This PR includes 2 minor and one sensible performance improvements:
- minor: avoid the memory cost of a string context key
- minor: avoid nil-checks by directly setting spanNameFunc
- use slice pools for attributes and options

The last one in particular has a sensible impact on allocations:

```
cpu: 12th Gen Intel(R) Core(TM) i7-1250U
          │  old.bench  │           new.bench           │
          │   sec/op    │   sec/op     vs base          │
Tracer-12   1.179m ± 3%   1.174m ± 3%  ~ (p=0.684 n=10)

          │   old.bench   │              new.bench               │
          │     B/op      │     B/op      vs base                │
Tracer-12   10.261Ki ± 0%   9.221Ki ± 0%  -10.13% (p=0.000 n=10)

          │ old.bench  │             new.bench              │
          │ allocs/op  │ allocs/op   vs base                │
Tracer-12   93.00 ± 0%   76.00 ± 0%  -18.28% (p=0.000 n=10)
```