### PR TITLE
feat: allow access to context in SpanName function

### DIFF
--- a/operation_name_go124.go
+++ b/operation_name_go124.go
@@ -4,12 +4,13 @@
 package otelpgx
 
 import (
+	"context"
 	"strings"
 )
 
-// defaultSpanNameFunc attempts to get the first 'word' from a given SQL query, which usually
+// defaultSpanNameCtxFunc attempts to get the first 'word' from a given SQL query, which usually
 // is the operation name (e.g. 'SELECT').
-func defaultSpanNameFunc(stmt string) string {
+func defaultSpanNameCtxFunc(_ context.Context, stmt string) string {
 	for word := range strings.FieldsSeq(stmt) {
 		return strings.ToUpper(word)
 	}

--- a/operation_name_legacy.go
+++ b/operation_name_legacy.go
@@ -4,13 +4,14 @@
 package otelpgx
 
 import (
+	"context"
 	"strings"
 	"unicode"
 )
 
-// defaultSpanNameFunc attempts to get the first 'word' from a given SQL query, which usually
+// defaultSpanNameCtxFunc attempts to get the first 'word' from a given SQL query, which usually
 // is the operation name (e.g. 'SELECT').
-func defaultSpanNameFunc(stmt string) string {
+func defaultSpanNameCtxFunc(_ context.Context, stmt string) string {
 	stmt = strings.TrimSpace(stmt)
 	end := strings.IndexFunc(stmt, unicode.IsSpace)
 	if end < 0 && len(stmt) > 0 {

--- a/options.go
+++ b/options.go
@@ -1,6 +1,7 @@
 package otelpgx
 
 import (
+	"context"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -74,14 +75,30 @@ func WithTrimSQLInSpanName() Option {
 // SQL. The function will be called with the SQL statement as a parameter.
 type SpanNameFunc func(stmt string) string
 
+// SpanNameCtxFunc is a function that can be used to generate a span name for a
+// SQL. The function will be called with the context.Context and SQL statement
+// as a parameter.
+type SpanNameCtxFunc func(ctx context.Context, stmt string) string
+
 // WithSpanNameFunc will use the provided function to generate the span name for
 // a SQL statement. The function will be called with the SQL statement as a
 // parameter.
 //
 // By default, the whole SQL statement is used as a span name, where applicable.
 func WithSpanNameFunc(fn SpanNameFunc) Option {
+	return WithSpanNameCtxFunc(func(_ context.Context, stmt string) string {
+		return fn(stmt)
+	})
+}
+
+// WithSpanNameCtxFunc will use the provided function to generate the span name
+// for a SQL statement. The function will be called with the context.Context and
+// SQL statement as a parameter.
+//
+// By default, the whole SQL statement is used as a span name, where applicable.
+func WithSpanNameCtxFunc(fn SpanNameCtxFunc) Option {
 	return optionFunc(func(cfg *tracerConfig) {
-		cfg.spanNameFunc = fn
+		cfg.spanNameCtxFunc = fn
 	})
 }
 

--- a/tracer.go
+++ b/tracer.go
@@ -75,7 +75,7 @@ type Tracer struct {
 	operationErrors   metric.Int64Counter
 
 	trimQuerySpanName    bool
-	spanNameFunc         SpanNameFunc
+	spanNameCtxFunc      SpanNameCtxFunc
 	prefixQuerySpanName  bool
 	logSQLStatement      bool
 	logConnectionDetails bool
@@ -90,7 +90,7 @@ type tracerConfig struct {
 	meterAttrs  []attribute.KeyValue
 
 	trimQuerySpanName    bool
-	spanNameFunc         SpanNameFunc
+	spanNameCtxFunc      SpanNameCtxFunc
 	prefixQuerySpanName  bool
 	logSQLStatement      bool
 	logConnectionDetails bool
@@ -109,7 +109,7 @@ func NewTracer(opts ...Option) *Tracer {
 			semconv.DBSystemPostgreSQL,
 		},
 		trimQuerySpanName:    false,
-		spanNameFunc:         defaultSpanNameFunc,
+		spanNameCtxFunc:      defaultSpanNameCtxFunc,
 		prefixQuerySpanName:  true,
 		logSQLStatement:      true,
 		logConnectionDetails: true,
@@ -135,14 +135,13 @@ func NewTracer(opts ...Option) *Tracer {
 				return &s
 			},
 		},
-		tracerAttrs:          cfg.tracerAttrs,
-		meterAttrs:           cfg.meterAttrs,
-		trimQuerySpanName:    cfg.trimQuerySpanName,
-		spanNameFunc:         cfg.spanNameFunc,
-		prefixQuerySpanName:  cfg.prefixQuerySpanName,
-		logSQLStatement:      cfg.logSQLStatement,
-		logConnectionDetails: cfg.logConnectionDetails,
-		includeParams:        cfg.includeParams,
+		tracerAttrs:         cfg.tracerAttrs,
+		meterAttrs:          cfg.meterAttrs,
+		trimQuerySpanName:   cfg.trimQuerySpanName,
+		spanNameCtxFunc:     cfg.spanNameCtxFunc,
+		prefixQuerySpanName: cfg.prefixQuerySpanName,
+		logSQLStatement:     cfg.logSQLStatement,
+		includeParams:       cfg.includeParams,
 	}
 
 	tracer.createMetrics()
@@ -266,7 +265,7 @@ func (t *Tracer) TraceQueryStart(ctx context.Context, conn *pgx.Conn, data pgx.T
 	if t.logSQLStatement {
 		attrs = append(attrs,
 			semconv.DBQueryText(data.SQL),
-			semconv.DBOperationName(t.spanNameFunc(data.SQL)),
+			semconv.DBOperationName(t.spanNameCtxFunc(ctx, data.SQL)),
 		)
 
 		if t.includeParams {
@@ -281,7 +280,7 @@ func (t *Tracer) TraceQueryStart(ctx context.Context, conn *pgx.Conn, data pgx.T
 
 	spanName := data.SQL
 	if t.trimQuerySpanName {
-		spanName = t.spanNameFunc(data.SQL)
+		spanName = t.spanNameCtxFunc(ctx, data.SQL)
 	}
 
 	if t.prefixQuerySpanName {
@@ -426,7 +425,7 @@ func (t *Tracer) TraceBatchQuery(ctx context.Context, conn *pgx.Conn, data pgx.T
 	if t.logSQLStatement {
 		attrs = append(attrs,
 			semconv.DBQueryText(data.SQL),
-			semconv.DBOperationName(t.spanNameFunc(data.SQL)),
+			semconv.DBOperationName(t.spanNameCtxFunc(ctx, data.SQL)),
 		)
 
 		if t.includeParams {
@@ -441,7 +440,7 @@ func (t *Tracer) TraceBatchQuery(ctx context.Context, conn *pgx.Conn, data pgx.T
 
 	var spanName string
 	if t.trimQuerySpanName {
-		spanName = t.spanNameFunc(data.SQL)
+		spanName = t.spanNameCtxFunc(ctx, data.SQL)
 		if t.prefixQuerySpanName {
 			spanName = "query " + spanName
 		}
@@ -544,7 +543,7 @@ func (t *Tracer) TracePrepareStart(ctx context.Context, conn *pgx.Conn, data pgx
 		attrs = append(attrs, connectionAttributesFromConfig(conn.Config())...)
 	}
 
-	attrs = append(attrs, semconv.DBOperationName(t.spanNameFunc(data.SQL)))
+	attrs = append(attrs, semconv.DBOperationName(t.spanNameCtxFunc(ctx, data.SQL)))
 
 	if t.logSQLStatement {
 		attrs = append(attrs, semconv.DBQueryText(data.SQL))
@@ -557,7 +556,7 @@ func (t *Tracer) TracePrepareStart(ctx context.Context, conn *pgx.Conn, data pgx
 
 	spanName := data.SQL
 	if t.trimQuerySpanName {
-		spanName = t.spanNameFunc(data.SQL)
+		spanName = t.spanNameCtxFunc(ctx, data.SQL)
 	}
 	if t.prefixQuerySpanName {
 		spanName = "prepare " + spanName


### PR DESCRIPTION
Add a new function, `WithSpanNameCtxFunc`, to allow extracting the span name from `context.Context`.

This provides a less opinionated solution, giving developers the flexibility to choose how to extract the span name - whether from `context.Context` or the SQL statement.

