### PR TITLE
fix: allow user to override default record stats meter attributes

### DIFF
--- a/meter.go
+++ b/meter.go
@@ -37,11 +37,18 @@ const (
 // RecordStats records database statistics for provided pgxpool.Pool at a default 1 second interval
 // unless otherwise specified by the WithMinimumReadDBStatsInterval StatsOption.
 func RecordStats(db PoolStats, opts ...StatsOption) error {
+	serverAddress := semconv.ServerAddress(db.Config().ConnConfig.Host)
+	serverPort := semconv.ServerPort(int(db.Config().ConnConfig.Port))
+	dbNamespace := semconv.DBNamespace(db.Config().ConnConfig.Database)
+	poolName := fmt.Sprintf("%s:%d/%s", serverAddress.Value.AsString(), serverPort.Value.AsInt64(), dbNamespace.Value.AsString())
+	dbClientConnectionPoolName := semconv.DBClientConnectionPoolName(poolName)
+
 	o := statsOptions{
 		meterProvider:              otel.GetMeterProvider(),
 		minimumReadDBStatsInterval: defaultMinimumReadDBStatsInterval,
 		defaultAttributes: []attribute.KeyValue{
 			semconv.DBSystemPostgreSQL,
+			dbClientConnectionPoolName,
 		},
 	}
 
@@ -92,12 +99,6 @@ func recordStats(
 		// lock prevents a race between batch observer and instrument registration.
 		lock sync.Mutex
 	)
-
-	serverAddress := semconv.ServerAddress(db.Config().ConnConfig.Host)
-	serverPort := semconv.ServerPort(int(db.Config().ConnConfig.Port))
-	dbNamespace := semconv.DBNamespace(db.Config().ConnConfig.Database)
-	poolName := fmt.Sprintf("%s:%d/%s", serverAddress.Value.AsString(), serverPort.Value.AsInt64(), dbNamespace.Value.AsString())
-	dbClientConnectionPoolName := semconv.DBClientConnectionPoolName(poolName)
 
 	lock.Lock()
 	defer lock.Unlock()
@@ -194,11 +195,6 @@ func recordStats(
 	); err != nil {
 		return fmt.Errorf("failed to create asynchronous metric: %s with error: %w", pgxPoolEmptyAcquireWaitTime, err)
 	}
-
-	attrs = append(attrs, []attribute.KeyValue{
-		semconv.DBSystemPostgreSQL,
-		dbClientConnectionPoolName,
-	}...)
 
 	observeOptions = []metric.ObserveOption{
 		metric.WithAttributeSet(attribute.NewSet(attrs...)),


### PR DESCRIPTION
Default metric attribute was appended at the end, making it impossible to override the default one from the user provided StatsOption. This commit ensure the default attributes, are always provided at the beginning, making it possible for the user to override those.

I've decided not to push a test, as it require to pull in too many deps and I did not want to pollute the library go.mod 
However you can check the [test](https://github.com/alessio-perugini/otelpgx/commit/78145e4c308f081db0053dcc84c437792a2c99dd#diff-a97e66319352fe19843b786b07cde726388c3b1b32e40d49f51854a4bb5d1a9d) in a dedicated branch I've created: https://github.com/alessio-perugini/otelpgx/tree/test-attribute-override.