### PR TITLE
fix: record db.client.operation.duration in seconds

### DIFF
--- a/tracer.go
+++ b/tracer.go
@@ -71,7 +71,7 @@ type Tracer struct {
 	attributeSlicePool   sync.Pool
 	metricAttrs          map[string]attribute.Set
 
-	operationDuration metric.Int64Histogram
+	operationDuration metric.Float64Histogram
 	operationErrors   metric.Int64Counter
 
 	trimQuerySpanName    bool
@@ -155,7 +155,7 @@ func NewTracer(opts ...Option) *Tracer {
 func (t *Tracer) createMetrics() {
 	var err error
 
-	t.operationDuration, err = t.meter.Int64Histogram(
+	t.operationDuration, err = t.meter.Float64Histogram(
 		semconv.DBClientOperationDurationName,
 		metric.WithDescription(semconv.DBClientOperationDurationDescription),
 		metric.WithUnit(semconv.DBClientOperationDurationUnit),
@@ -217,7 +217,7 @@ func (t *Tracer) incrementOperationErrorCount(ctx context.Context, err error, pg
 // recordOperationDuration will compute and record the time since the start of an operation.
 func (t *Tracer) recordOperationDuration(ctx context.Context, pgxOperation string) {
 	if startTime, ok := ctx.Value(startTimeCtxKey{}).(time.Time); ok {
-		t.operationDuration.Record(ctx, time.Since(startTime).Milliseconds(), metric.WithAttributeSet(
+		t.operationDuration.Record(ctx, time.Since(startTime).Seconds(), metric.WithAttributeSet(
 			t.metricAttrs[pgxOperation],
 		))
 	}


### PR DESCRIPTION
## Summary

Fixes #70.

The `db.client.operation.duration` instrument declares unit `"s"` per the OpenTelemetry semantic conventions (`semconv.DBClientOperationDurationUnit = "s"`), but `recordOperationDuration` was recording integer milliseconds via `time.Duration.Milliseconds()`. This causes the Prometheus exporter to emit a `db_client_operation_duration_seconds` metric whose values and bucket boundaries are actually in milliseconds — making the metric name actively misleading and any histogram quantile queries return incorrect results.

## Change

- `operationDuration`: `metric.Int64Histogram` → `metric.Float64Histogram`
- `createMetrics`: `meter.Int64Histogram` → `meter.Float64Histogram`
- `recordOperationDuration`: `time.Since(startTime).Milliseconds()` → `time.Since(startTime).Seconds()`

## Notes

This is a **breaking change** for existing Prometheus users: bucket `le` labels and all recorded values will shift from millisecond-range integers (e.g. `le="5"` for 5ms) to second-range floats (e.g. `le="0.005"`). Users with custom histogram views or dashboards querying bucket boundaries by value will need to update them.