### PR TITLE
Trim when span name func is set

### DIFF
--- a/options.go
+++ b/options.go
@@ -98,6 +98,7 @@ func WithSpanNameFunc(fn SpanNameFunc) Option {
 // By default, the whole SQL statement is used as a span name, where applicable.
 func WithSpanNameCtxFunc(fn SpanNameCtxFunc) Option {
 	return optionFunc(func(cfg *tracerConfig) {
+		cfg.trimQuerySpanName = true
 		cfg.spanNameCtxFunc = fn
 	})
 }


### PR DESCRIPTION
Fix for issue https://github.com/exaring/otelpgx/issues/32.

Simply set `cfg.trimQuerySpanName = true` when a `SpanNameFunc` is set. This should fix some confusion around having to explicitly set `WithTrimSQLInSpanName` when using a custom func because of https://github.com/exaring/otelpgx/blob/175265042c8836c7cb1e228becf4adf625e8920a/tracer.go#L277