### PR TITLE
fix: Tracer.logConnectionDetails defaults to true

### DIFF
--- a/tracer.go
+++ b/tracer.go
@@ -145,6 +145,7 @@ func NewTracer(opts ...Option) *Tracer {
 		spanNameCtxFunc:      cfg.spanNameCtxFunc,
 		prefixQuerySpanName:  cfg.prefixQuerySpanName,
 		logSQLStatement:      cfg.logSQLStatement,
+		logConnectionDetails: cfg.logConnectionDetails,
 		includeParams:        cfg.includeParams,
 		disableAcquireTracer: cfg.disableAcquireTracer,
 	}

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -2,10 +2,17 @@ package otelpgx
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"strings"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgproto3"
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 func TestTracer_sqlOperationName(t *testing.T) {
@@ -170,6 +177,221 @@ func TestTracer_sqlOperationNameFromCtx(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			assert.Equal(t, tt.exp, tracer.spanNameCtxFunc(tt.ctx, "SELECT * FROM users"))
+		})
+	}
+}
+
+// newMockConn creates a *pgx.Conn with the given connection details, backed
+// by a fake PostgreSQL server over net.Pipe — no real database needed.
+func newMockConn(t *testing.T, host string, port uint16, user, database string) *pgx.Conn {
+	t.Helper()
+
+	client, server := net.Pipe()
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer server.Close()
+
+		b := pgproto3.NewBackend(server, server)
+		if _, err := b.ReceiveStartupMessage(); err != nil {
+			errCh <- fmt.Errorf("receive startup: %w", err)
+			return
+		}
+
+		for _, msg := range []pgproto3.BackendMessage{
+			&pgproto3.AuthenticationOk{},
+			&pgproto3.BackendKeyData{},
+			&pgproto3.ReadyForQuery{TxStatus: 'I'},
+		} {
+			b.Send(msg)
+		}
+		if err := b.Flush(); err != nil {
+			errCh <- fmt.Errorf("flush: %w", err)
+			return
+		}
+
+		// Drain until the client disconnects or sends Terminate.
+		for {
+			msg, err := b.Receive()
+			if err != nil {
+				break
+			}
+			if _, ok := msg.(*pgproto3.Terminate); ok {
+				break
+			}
+		}
+		errCh <- nil
+	}()
+
+	dsn := fmt.Sprintf("postgres://%s@%s:%d/%s?sslmode=disable", user, host, int(port), database)
+	config, err := pgx.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	config.LookupFunc = func(ctx context.Context, host string) ([]string, error) {
+		return []string{host}, nil
+	}
+	config.DialFunc = func(ctx context.Context, _, _ string) (net.Conn, error) {
+		return client, nil
+	}
+
+	conn, err := pgx.ConnectConfig(context.Background(), config)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	t.Cleanup(func() {
+		conn.Close(context.Background())
+		if serverErr := <-errCh; serverErr != nil {
+			t.Errorf("mock server: %v", serverErr)
+		}
+	})
+
+	return conn
+}
+
+// findAttr returns the value for the given key in the attribute slice, and
+// whether it was found.
+func findAttr(attrs []attribute.KeyValue, key string) (attribute.Value, bool) {
+	for _, a := range attrs {
+		if string(a.Key) == key {
+			return a.Value, true
+		}
+	}
+	return attribute.Value{}, false
+}
+
+func TestTracer_spanAttributes(t *testing.T) {
+	conn := newMockConn(t, "fakehost", 5432, "fakeuser", "fakedb")
+
+	tests := []struct {
+		name         string
+		opts         []Option
+		drive        func(ctx context.Context, tracer *Tracer, conn *pgx.Conn)
+		wantStrAttrs map[string]string
+		wantIntAttrs map[string]int64
+		absentAttrs  []string
+	}{
+		{
+			name: "query default",
+			drive: func(ctx context.Context, tracer *Tracer, conn *pgx.Conn) {
+				ctx = tracer.TraceQueryStart(ctx, conn, pgx.TraceQueryStartData{SQL: "SELECT * FROM users"})
+				tracer.TraceQueryEnd(ctx, conn, pgx.TraceQueryEndData{})
+			},
+			wantStrAttrs: map[string]string{
+				"db.system.name":    "postgresql",
+				"server.address":    "fakehost",
+				"user.name":         "fakeuser",
+				"db.namespace":      "fakedb",
+				"db.query.text":     "SELECT * FROM users",
+				"db.operation.name": "SELECT",
+			},
+			wantIntAttrs: map[string]int64{
+				"server.port": 5432,
+			},
+		},
+		{
+			name: "query without connection details",
+			opts: []Option{WithDisableConnectionDetailsInAttributes()},
+			drive: func(ctx context.Context, tracer *Tracer, conn *pgx.Conn) {
+				ctx = tracer.TraceQueryStart(ctx, conn, pgx.TraceQueryStartData{SQL: "SELECT * FROM users"})
+				tracer.TraceQueryEnd(ctx, conn, pgx.TraceQueryEndData{})
+			},
+			wantStrAttrs: map[string]string{
+				"db.system.name":    "postgresql",
+				"db.query.text":     "SELECT * FROM users",
+				"db.operation.name": "SELECT",
+			},
+			absentAttrs: []string{"server.address", "server.port", "user.name", "db.namespace"},
+		},
+		{
+			name: "query without SQL statement",
+			opts: []Option{WithDisableSQLStatementInAttributes()},
+			drive: func(ctx context.Context, tracer *Tracer, conn *pgx.Conn) {
+				ctx = tracer.TraceQueryStart(ctx, conn, pgx.TraceQueryStartData{SQL: "SELECT * FROM users"})
+				tracer.TraceQueryEnd(ctx, conn, pgx.TraceQueryEndData{})
+			},
+			wantStrAttrs: map[string]string{
+				"db.system.name": "postgresql",
+				"server.address": "fakehost",
+				"user.name":      "fakeuser",
+				"db.namespace":   "fakedb",
+			},
+			wantIntAttrs: map[string]int64{
+				"server.port": 5432,
+			},
+			absentAttrs: []string{"db.query.text", "db.operation.name"},
+		},
+		{
+			name: "query with parameters included",
+			opts: []Option{WithIncludeQueryParameters()},
+			drive: func(ctx context.Context, tracer *Tracer, conn *pgx.Conn) {
+				ctx = tracer.TraceQueryStart(ctx, conn, pgx.TraceQueryStartData{
+					SQL:  "SELECT * FROM users WHERE id = $1",
+					Args: []any{42},
+				})
+				tracer.TraceQueryEnd(ctx, conn, pgx.TraceQueryEndData{})
+			},
+			wantStrAttrs: map[string]string{
+				"db.system.name":    "postgresql",
+				"server.address":    "fakehost",
+				"user.name":         "fakeuser",
+				"db.namespace":      "fakedb",
+				"db.query.text":     "SELECT * FROM users WHERE id = $1",
+				"db.operation.name": "SELECT",
+			},
+			wantIntAttrs: map[string]int64{
+				"server.port": 5432,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exporter := tracetest.NewInMemoryExporter()
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+			defer tp.Shutdown(context.Background())
+
+			opts := append([]Option{WithTracerProvider(tp)}, tt.opts...)
+			tracer := NewTracer(opts...)
+
+			ctx, parentSpan := tp.Tracer("test").Start(context.Background(), "parent")
+			tt.drive(ctx, tracer, conn)
+			parentSpan.End()
+
+			spans := exporter.GetSpans()
+			if len(spans) < 1 {
+				t.Fatal("no spans recorded")
+			}
+			span := spans[0]
+
+			for key, want := range tt.wantStrAttrs {
+				v, ok := findAttr(span.Attributes, key)
+				if !ok {
+					t.Errorf("missing attribute %q", key)
+					continue
+				}
+				if got := v.AsString(); got != want {
+					t.Errorf("attr %q = %q, want %q", key, got, want)
+				}
+			}
+
+			for key, want := range tt.wantIntAttrs {
+				v, ok := findAttr(span.Attributes, key)
+				if !ok {
+					t.Errorf("missing attribute %q", key)
+					continue
+				}
+				if got := v.AsInt64(); got != want {
+					t.Errorf("attr %q = %d, want %d", key, got, want)
+				}
+			}
+
+			for _, key := range tt.absentAttrs {
+				if _, ok := findAttr(span.Attributes, key); ok {
+					t.Errorf("unexpected attribute %q present", key)
+				}
+			}
 		})
 	}
 }

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgproto3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
@@ -200,7 +201,7 @@ func newMockConn(t *testing.T, host string, port uint16, user, database string) 
 
 		for _, msg := range []pgproto3.BackendMessage{
 			&pgproto3.AuthenticationOk{},
-			&pgproto3.BackendKeyData{},
+			&pgproto3.BackendKeyData{SecretKey: make([]byte, 4)},
 			&pgproto3.ReadyForQuery{TxStatus: 'I'},
 		} {
 			b.Send(msg)
@@ -225,9 +226,8 @@ func newMockConn(t *testing.T, host string, port uint16, user, database string) 
 
 	dsn := fmt.Sprintf("postgres://%s@%s:%d/%s?sslmode=disable", user, host, int(port), database)
 	config, err := pgx.ParseConfig(dsn)
-	if err != nil {
-		t.Fatalf("parse config: %v", err)
-	}
+	require.NoError(t, err)
+
 	config.LookupFunc = func(ctx context.Context, host string) ([]string, error) {
 		return []string{host}, nil
 	}
@@ -236,9 +236,7 @@ func newMockConn(t *testing.T, host string, port uint16, user, database string) 
 	}
 
 	conn, err := pgx.ConnectConfig(context.Background(), config)
-	if err != nil {
-		t.Fatalf("connect: %v", err)
-	}
+	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		conn.Close(context.Background())
@@ -360,37 +358,25 @@ func TestTracer_spanAttributes(t *testing.T) {
 			parentSpan.End()
 
 			spans := exporter.GetSpans()
-			if len(spans) < 1 {
-				t.Fatal("no spans recorded")
-			}
+			require.Greater(t, len(spans), 0, "no spans recorded")
+
 			span := spans[0]
 
 			for key, want := range tt.wantStrAttrs {
 				v, ok := findAttr(span.Attributes, key)
-				if !ok {
-					t.Errorf("missing attribute %q", key)
-					continue
-				}
-				if got := v.AsString(); got != want {
-					t.Errorf("attr %q = %q, want %q", key, got, want)
-				}
+				require.Truef(t, ok, "missing attribute %q", key)
+				require.Equalf(t, want, v.AsString(), "attr %q = %q, want %q", key, v.AsString(), want)
 			}
 
 			for key, want := range tt.wantIntAttrs {
 				v, ok := findAttr(span.Attributes, key)
-				if !ok {
-					t.Errorf("missing attribute %q", key)
-					continue
-				}
-				if got := v.AsInt64(); got != want {
-					t.Errorf("attr %q = %d, want %d", key, got, want)
-				}
+				require.Truef(t, ok, "missing attribute %q", key)
+				require.Equalf(t, want, v.AsInt64(), "attr %q = %q, want %d", key, v.AsInt64(), want)
 			}
 
 			for _, key := range tt.absentAttrs {
-				if _, ok := findAttr(span.Attributes, key); ok {
-					t.Errorf("unexpected attribute %q present", key)
-				}
+				_, ok := findAttr(span.Attributes, key)
+				require.Falsef(t, ok, "unexpected attribute %q present")
 			}
 		})
 	}

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -191,11 +191,17 @@ func newMockConn(t *testing.T, host string, port uint16, user, database string) 
 	errCh := make(chan error, 1)
 
 	go func() {
-		defer server.Close()
+		var gErr error
+		defer func() {
+			if err := server.Close(); err != nil && gErr == nil {
+				gErr = fmt.Errorf("server close: %w", err)
+			}
+			errCh <- gErr
+		}()
 
 		b := pgproto3.NewBackend(server, server)
 		if _, err := b.ReceiveStartupMessage(); err != nil {
-			errCh <- fmt.Errorf("receive startup: %w", err)
+			gErr = fmt.Errorf("receive startup: %w", err)
 			return
 		}
 
@@ -207,7 +213,7 @@ func newMockConn(t *testing.T, host string, port uint16, user, database string) 
 			b.Send(msg)
 		}
 		if err := b.Flush(); err != nil {
-			errCh <- fmt.Errorf("flush: %w", err)
+			gErr = fmt.Errorf("flush: %w", err)
 			return
 		}
 
@@ -221,7 +227,6 @@ func newMockConn(t *testing.T, host string, port uint16, user, database string) 
 				break
 			}
 		}
-		errCh <- nil
 	}()
 
 	dsn := fmt.Sprintf("postgres://%s@%s:%d/%s?sslmode=disable", user, host, int(port), database)
@@ -239,7 +244,9 @@ func newMockConn(t *testing.T, host string, port uint16, user, database string) 
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		conn.Close(context.Background())
+		if err := conn.Close(context.Background()); err != nil {
+			t.Errorf("close conn: %v", err)
+		}
 		if serverErr := <-errCh; serverErr != nil {
 			t.Errorf("mock server: %v", serverErr)
 		}
@@ -348,7 +355,7 @@ func TestTracer_spanAttributes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			exporter := tracetest.NewInMemoryExporter()
 			tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
-			defer tp.Shutdown(context.Background())
+			t.Cleanup(func() { require.NoError(t, tp.Shutdown(context.Background())) })
 
 			opts := append([]Option{WithTracerProvider(tp)}, tt.opts...)
 			tracer := NewTracer(opts...)


### PR DESCRIPTION
From my understanding, the `Tracer.logConnectionDetails` is meant to default to `true` (going by how the config struct is initialized in `NewTracer`), and using `WithDisableConnectionDetailsInAttributes` to set it to `false`.

This PR is a fix so the tracer behaves as described above.

I've also added a table of tests making assertions about what attributes are present in traces under different configurations. Since these tests set up a mock pg connection, the changes to tests are quite verbose. I'll be more than happy to get any suggestions on better ways of testing the attributes behaviour (or any other suggestions, for that matter).