### PR TITLE
Add explicit bucket boundaries for db.client.operation.duration metric

### DIFF
--- a/tracer.go
+++ b/tracer.go
@@ -17,7 +17,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
-	dbconv "go.opentelemetry.io/otel/semconv/v1.40.0/dbconv"
+	"go.opentelemetry.io/otel/semconv/v1.40.0/dbconv"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -161,7 +161,12 @@ func NewTracer(opts ...Option) *Tracer {
 func (t *Tracer) createMetrics() {
 	var err error
 
-	t.operationDuration, err = dbconv.NewClientOperationDuration(t.meter)
+	t.operationDuration, err = dbconv.NewClientOperationDuration(
+		t.meter,
+		metric.WithExplicitBucketBoundaries(
+			0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10,
+		),
+	)
 	if err != nil {
 		otel.Handle(err)
 	}


### PR DESCRIPTION
The [semantic conventions](https://opentelemetry.io/docs/specs/semconv/db/database-metrics/#metric-dbclientoperationduration) for this metric specify:

> This metric SHOULD be specified with [ExplicitBucketBoundaries advisory parameter](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.56.0/specification/metrics/api.md#instrument-advisory-parameters) of [ 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10 ].

The default values for bucket boundaries are `[]float64{0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000}` ([code](https://github.com/open-telemetry/opentelemetry-go/blob/v1.44.0/sdk/metric/reader.go#L206)). This works well when working with milliseconds but this metric is calculated in seconds.

This PR aligns the metric with the semantic conventions.